### PR TITLE
Add Makefile to build common commands more easily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: site show-site
+
+site:
+	ttree -a -v -l LIB -f .ttreerc -s . -d /tmp/yef
+
+show-site:
+	firefox file:///tmp/yef/index.html

--- a/README
+++ b/README
@@ -6,11 +6,15 @@ $> git clone https://github.com/yapceurope/yef-www/
 # Change location.
 $> cd yef-www/
 
-# Make sure you have Template::Plugin::YAML installed.
-# Run the Template Toolkit commandline tool to build the site.
+# Build the site
+$> make site
+or
 $> ttree  -a -v -l LIB -f .ttreerc -s . -d /tmp/yef
 
-# Point your browser at the newly created (local) site.
+# View the local site in Firefox
+$> make show-site
+
+# Alternatively, point your browser at the newly created (local) site directly
 $> firefox file:///tmp/yef/index.html
 
 # Not sure why, but on my box, all links point to /home/yapc/public_html


### PR DESCRIPTION
After walking through the commands in the README, I thought maybe a Makefile would reduce typing, especially for common commands.  The `make` behaviour mirrors that which is mentioned in the docs and extends the docs to mention the alternate method for building and viewing the local site.

This PR is submitted in the hope that it is helpful.  If you want anything changed, please simply let me know and I'll update and resubmit as necessary.